### PR TITLE
Potential fix for code scanning alert no. 13: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -248,8 +248,8 @@ def get_chat(target_user_id):
             'adminUid': admin_uid # Pass adminUid back for message rendering logic
         })
     except Exception as e:
-        print(f"Error fetching chat: {e}")
-        return jsonify({'error': f'Failed to fetch chat: {e}'}), 500
+        print(f"Error fetching chat: {e}")  # Log the exception details on the server
+        return jsonify({'error': 'An internal error occurred while fetching the chat.'}), 500
 
 @app.route('/send_message/<chat_id>', methods=['POST'])
 def send_message(chat_id):
@@ -272,8 +272,8 @@ def send_message(chat_id):
         })
         return jsonify({'success': True, 'message': 'Message sent!'}), 200
     except Exception as e:
-        print(f"Error sending message: {e}")
-        return jsonify({'error': f'Failed to send message: {e}'}), 500
+        print(f"Error sending message: {e}")  # Log the exception details on the server
+        return jsonify({'error': 'An internal error occurred while sending the message.'}), 500
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/13](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/13)

To fix the issue, the exception message should not be included in the response sent to the client. Instead, a generic error message should be returned to the user, while the detailed exception information is logged on the server for debugging purposes. This ensures that sensitive information is not exposed externally but remains accessible to developers for troubleshooting.

The changes required are:
1. Replace the line that returns the exception message (`{'error': f'Failed to send message: {e}'}`) with a generic error message (`{'error': 'An internal error occurred while sending the message.'}`).
2. Log the exception details (`e`) on the server using `print` or a logging library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
