### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,5 +1,8 @@
 name: NodeJS with Grunt CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/1](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily reads repository contents and does not perform any write operations, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build-and-test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
