### PR TITLE
Potential fix for code scanning alert no. 6: Information exposure through an exception

### DIFF
--- a/fastapi.py
+++ b/fastapi.py
@@ -17,7 +17,9 @@ def get_moments():
         docs = db.collection('moments').stream()
         return jsonify([doc.to_dict() for doc in docs])
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        import logging
+        logging.error("An error occurred: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred'}), 500
 
 @app.route('/api/delete-moment', methods=['POST'])
 def delete_moment():
@@ -26,4 +28,6 @@ def delete_moment():
         db.collection('moments').document(moment_id).delete()
         return jsonify({'success': True})
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        import logging
+        logging.error("An error occurred: %s", e, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/6](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/6)

To fix the issue, the exception message should not be directly exposed to the user. Instead, a generic error message should be returned to the user, while the actual exception details (including stack traces) should be logged on the server for debugging purposes. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

The changes involve:
1. Replacing the `{'error': str(e)}` response with a generic error message like `{'error': 'An internal error has occurred'}`.
2. Logging the exception details (e.g., using Python's `logging` module) to capture the stack trace for debugging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
