### PR TITLE
Potential fix for code scanning alert no. 11: Information exposure through an exception

### DIFF
--- a/flaskapi.py
+++ b/flaskapi.py
@@ -148,7 +148,8 @@ def send_message():
         db.collection('chats').document(chat_id).collection('messages').add(message)
         return jsonify({"success": True})
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error("An error occurred while sending a message: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error occurred"}), 500
 
 if __name__ == '__main__':
     app.run(port=5000)


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/11](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/11)

To fix the issue, we should avoid exposing the raw exception message to the user. Instead, we can log the exception details on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

Steps to implement the fix:
1. Replace the `return jsonify({"error": str(e)})` statement with a generic error message like `{"error": "An internal error occurred"}`.
2. Log the exception details (e.g., stack trace) on the server using a logging library such as Python's built-in `logging` module.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
