### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/firebase-grunt.yml
+++ b/.github/workflows/firebase-grunt.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 env:
   FIREBASE_PROJECT: your-project-id  # Set your Firebase project ID
 


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/2](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to require write access to repository contents or other resources, we will set the permissions to `contents: read` at the workflow level. This will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. This change ensures that the `GITHUB_TOKEN` has only the minimal permissions required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
