### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/4](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/4)

To fix the issue, add a `permissions` block to the `build` job to explicitly limit the `GITHUB_TOKEN` permissions to the minimum required. Since the `build` job only needs to read the repository contents (e.g., for checking out the code and running tests), the `contents: read` permission is sufficient. This change ensures that the job cannot perform any unintended write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
