### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/flaskapi.py
+++ b/flaskapi.py
@@ -24,7 +24,7 @@ def get_users():
         return jsonify(users)
     except Exception as e:
         print(e)  # Log error
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 @app.route('/api/ban-user', methods=['POST'])
 def ban_user():
@@ -35,7 +35,8 @@ def ban_user():
         db.collection('users').document(user_id).update({'banned': True})
         return jsonify({"success": True, "message": "User banned."})
     except Exception as e:
-        return jsonify({"success": False, "message": str(e)}), 500
+        print(e)  # Log error
+        return jsonify({"success": False, "message": "An internal error has occurred."}), 500
 
 # --- MOMENTS ---
 
@@ -72,7 +73,8 @@ def delete_moment():
         db.collection('moments').document(moment_id).delete()
         return jsonify({"success": True})
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        print(e)  # Log error
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 # --- STATISTICS ---
 


### PR DESCRIPTION
Potential fix for [https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/8](https://github.com/spoiler254-hub/spoiler254-hub/security/code-scanning/8)

To fix the issue, the code should be updated to return a generic error message to the user instead of exposing the exception details. The exception details should be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

The changes involve:
1. Replacing `{"error": str(e)}` with a generic error message like `{"error": "An internal error has occurred."}`.
2. Logging the exception details (`str(e)`) on the server using `print()` or a logging library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
